### PR TITLE
fix GeoCalendar tests

### DIFF
--- a/test/unit/specs/elements/GeoCalendar/GeoCalendar.spec.js
+++ b/test/unit/specs/elements/GeoCalendar/GeoCalendar.spec.js
@@ -839,19 +839,6 @@ function getWrappedComponent () {
       latestDatePlaceholder: 'Latest date',
       pickerGranularity: '<div> Granularity Selectors </div>'
     },
-    data () {
-      return {
-        fromFormattedDate: '',
-        toFormattedDate: '',
-        fromRawDate: null,
-        toRawDate: null,
-        currentMonth: 6,
-        showFromFormatError: false,
-        showToFormatError: false,
-        currentInitialYearInRange: 0,
-        currentEndYearInRange: 0
-      }
-    },
     propsData: {
       calendarNavigationSelectIcon: ['fas', 'arrow-left'],
       nextDateInSelectedGranularityIcon: ['fas', 'arrow-left'],

--- a/test/unit/specs/elements/GeoCalendar/GeoCalendar.spec.js
+++ b/test/unit/specs/elements/GeoCalendar/GeoCalendar.spec.js
@@ -248,7 +248,7 @@ describe('GeoCalendar', () => {
           currentYear: getYear(invalidFromDateRange)
         })
 
-        wrapper.vm.selectMonth(getMonth(invalidFromDateRange), true)
+        wrapper.vm.selectMonth(getMonth(invalidFromDateRange))
         expect(wrapper.vm.fromRawDate).toEqual(startOfMonth(endDate))
         expect(wrapper.vm.toRawDate).toEqual(endOfMonth(invalidFromDateRange))
         expect(wrapper.vm.fromFormattedDate).toBe('01/11/2019')

--- a/test/unit/specs/elements/GeoCalendar/GeoCalendar.spec.js
+++ b/test/unit/specs/elements/GeoCalendar/GeoCalendar.spec.js
@@ -98,6 +98,9 @@ describe('GeoCalendar', () => {
     describe('selectMonth', () => {
       it('Sets first day of month in from input', () => {
         const wrapper = getWrappedComponent()
+        wrapper.setData({
+          currentYear: getYear(today)
+        })
         const calendarPicker = wrapper.vm.$refs.calendarPicker
         calendarPicker.$emit('select-month', 8)
         expect(wrapper.vm.currentMonth).toBe(8)
@@ -110,6 +113,9 @@ describe('GeoCalendar', () => {
 
       it('Sets last day of month in to input', () => {
         const wrapper = getWrappedComponent()
+        wrapper.setData({
+          currentYear: getYear(today)
+        })
         wrapper.setData({
           lastInputFieldFocused: FOCUSABLE_INPUT_FIELDS.FROM_DATE
         })
@@ -127,6 +133,9 @@ describe('GeoCalendar', () => {
 
     it('selectQuarter', () => {
       const wrapper = getWrappedComponent()
+      wrapper.setData({
+        currentYear: getYear(today)
+      })
       const calendarPicker = wrapper.vm.$refs.calendarPicker
       calendarPicker.$emit('select-quarter', 3)
       const fromDate = startOfQuarter(new Date(wrapper.vm.currentYear, 3))
@@ -229,15 +238,17 @@ describe('GeoCalendar', () => {
         const invalidFromDateRange = addMonths(endDate, 5)
         const geoFromInput = wrapper.findAll(GeoInput).at(0)
 
+        wrapper.setData({
+          currentYear: getYear(today)
+        })
         wrapper.vm.selectMonth(initialMonth)
         wrapper.vm.selectMonth(getMonth(endDate))
         geoFromInput.vm.$emit('focus')
-
         wrapper.setData({
           currentYear: getYear(invalidFromDateRange)
         })
 
-        wrapper.vm.selectMonth(getMonth(invalidFromDateRange))
+        wrapper.vm.selectMonth(getMonth(invalidFromDateRange), true)
         expect(wrapper.vm.fromRawDate).toEqual(startOfMonth(endDate))
         expect(wrapper.vm.toRawDate).toEqual(endOfMonth(invalidFromDateRange))
         expect(wrapper.vm.fromFormattedDate).toBe('01/11/2019')
@@ -835,7 +846,6 @@ function getWrappedComponent () {
         fromRawDate: null,
         toRawDate: null,
         currentMonth: 6,
-        currentYear: 2019,
         showFromFormatError: false,
         showToFormatError: false,
         currentInitialYearInRange: 0,

--- a/test/unit/specs/elements/GeoCalendar/GeoCalendarNavigation/GeoCalendarNavigationDay.spec.js
+++ b/test/unit/specs/elements/GeoCalendar/GeoCalendarNavigation/GeoCalendarNavigationDay.spec.js
@@ -8,6 +8,8 @@ import getYear from 'date-fns/getYear'
 import subYears from 'date-fns/subYears'
 import addYears from 'date-fns/addYears'
 
+const today = new Date(2019, 6, 30) // Fixed date to avoid future errors with random dates
+
 describe('GeoCalendarNavigationDay', () => {
   it('Should render', function () {
     const wrapper = mount(GeoCalendarNavigationDay, {
@@ -144,7 +146,7 @@ describe('GeoCalendarNavigationDay', () => {
 
 function setDateConstraints (wrapper) {
   wrapper.setProps({
-    earliestDate: subYears(new Date(), 5),
-    latestDate: addYears(new Date(), 5)
+    earliestDate: subYears(today, 5),
+    latestDate: addYears(today, 5)
   })
 }

--- a/test/unit/specs/elements/GeoCalendar/GeoCalendarNavigation/GeoCalendarNavigationMonth.spec.js
+++ b/test/unit/specs/elements/GeoCalendar/GeoCalendarNavigation/GeoCalendarNavigationMonth.spec.js
@@ -8,6 +8,8 @@ import getYear from 'date-fns/getYear'
 import subYears from 'date-fns/subYears'
 import addYears from 'date-fns/addYears'
 
+const today = new Date(2019, 6, 30) // Fixed date to avoid future errors with random dates
+
 describe('GeoCalendarNavigationMonth', () => {
   it('Should render', function () {
     const wrapper = mount(GeoCalendarNavigationMonth, {
@@ -107,7 +109,7 @@ describe('GeoCalendarNavigationMonth', () => {
 
 function setDateConstraints (wrapper) {
   wrapper.setProps({
-    earliestDate: subYears(new Date(), 5),
-    latestDate: addYears(new Date(), 5)
+    earliestDate: subYears(today, 5),
+    latestDate: addYears(today, 5)
   })
 }


### PR DESCRIPTION
- set `currentYear` to a fixed one before selecting month or quarters
- use fixed Date for `GeoCalendarNavigationDay` and `GeoCalendarNavigationMonth`