### PR TITLE
fix scatter plot and quadrant & add prop for axes

### DIFF
--- a/.vuepress/styles/_geo-chart-demos.scss
+++ b/.vuepress/styles/_geo-chart-demos.scss
@@ -1,3 +1,5 @@
+$DEFAULT_LINE_HEIGHT: 12px;
+
 .u-geo-chart--hidden-axis .geo-chart-axis {
   display: none;
 }
@@ -12,6 +14,25 @@
     line {
       display: none;
     }
+  }
+}
+
+.geo-chart-axis--with-quadrant {
+  .domain,
+  line {
+    display: none;
+  }
+  &.geo-chart-axis--left text {
+    transform: translate(-$DEFAULT_LINE_HEIGHT, 0)
+  }
+  &.geo-chart-axis--top text {
+    transform: translate(0, -$DEFAULT_LINE_HEIGHT)
+  }
+  &.geo-chart-axis--bottom text {
+    transform: translate(0, $DEFAULT_LINE_HEIGHT)
+  }
+  &.geo-chart-axis--right text {
+    transform: translate($DEFAULT_LINE_HEIGHT, 0)
   }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 29.4.1
+
+Fix:
+
+- label position in `GeoChartQuadrant`
+- handle click event from external component in `GeoChartScatterPlot`
+
+New:
+
+- `forceTickCount` in `ticks` property of `GeoChartAxis`
+
 ## 29.4.0
 
 New:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ New:
 
 - `GeoCalendar` Row containing day names is now properly aligned
 
-
 ## 29.4.0
 
 New:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "29.4.0",
+  "version": "29.4.1-beta.4",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/src/elements/GeoChart/GeoChart.02.chart-axes.examples.md
+++ b/src/elements/GeoChart/GeoChart.02.chart-axes.examples.md
@@ -62,6 +62,12 @@ config object. The value for that key must be an object with the following
 properties, all of them optional:
 
 - `count` - to customize the amount of ticks displayed. Must be an integer number.
+
+::: tip NOTE
+By default, d3 will only show a number of ticks which is a multiple of 2, 5 or 10. In order to force another number of ticks, use `forceTickCount` associated with `count`.
+:::
+
+- `forceTickCount` - boolean to force the number of ticks displayed. It will create a specific number of ticks between the axis domain range.
 - `format` - function taking as first parameter the value of the axis in the
 domain and as second parameter its index. Should return a string with the text
 to be displayed as value for given tick.
@@ -402,6 +408,83 @@ export default {
           }
         }]
       }
+    }
+  }
+}
+</script>
+```
+
+#### Forced tick number
+
+```vue live
+<template>
+  <div class="element-demo">
+    <div class="element-demo__block element-demo__block--chart-container">
+      <geo-chart
+        v-if="chartConfig"
+        :config="chartConfig"
+      />
+    </div>
+    <div class="element-demo__block__config">
+      <geo-primary-button @click="randomizeData()">
+        Randomize data
+      </geo-primary-button>
+    </div>
+  </div>
+</template>
+
+<script>
+const CONSTANTS = require('@/elements/GeoChart/constants')
+
+export default {
+  name: 'GeoChartAxisDemo',
+  data () {
+    return {
+      tickNumber: 5,
+      domainRangeStart: 0,
+      domainRangeEnd: 100,
+      valueForOrigin: 0
+    }
+  },
+  computed: {
+    chartConfig () {
+      return {
+        chart: {
+          margin: {
+            top: 30,
+            right: 30,
+            bottom: 30,
+            left: 200
+          }
+        },
+        axisGroups: [{
+          id: 'demo-linear-axis',
+          keyForValues: 'y',
+          position: {
+            type: CONSTANTS.AXIS.POSITIONS.left
+          },
+          scale: {
+            type: CONSTANTS.SCALES.SCALE_TYPES.linear,
+            valueForOrigin: this.valueForOrigin,
+            domain: {
+              start: this.domainRangeStart,
+              end: this.domainRangeEnd
+            }
+          },
+          ticks: {
+            count: this.tickNumber,
+            forceTickCount: true
+          }
+        }]
+      }
+    }
+  },
+  methods: {
+    randomizeData () {
+      this.domainRangeStart = _.random(-200, 200)
+      this.domainRangeEnd = _.random(-200, 200)
+      this.valueForOrigin = _.random(this.domainRangeStart, this.domainRangeEnd)
+      this.tickNumber = _.random(1, 10)
     }
   }
 }

--- a/src/elements/GeoChart/GeoChart.02.chart-axes.examples.md
+++ b/src/elements/GeoChart/GeoChart.02.chart-axes.examples.md
@@ -484,7 +484,7 @@ export default {
       this.domainRangeStart = _.random(-200, 200)
       this.domainRangeEnd = _.random(-200, 200)
       this.valueForOrigin = _.random(this.domainRangeStart, this.domainRangeEnd)
-      this.tickNumber = _.random(1, 10)
+      this.tickNumber = _.random(2, 10)
     }
   }
 }

--- a/src/elements/GeoChart/GeoChart.12.quadrant.examples.md
+++ b/src/elements/GeoChart/GeoChart.12.quadrant.examples.md
@@ -240,9 +240,6 @@ export default {
       return {
         id: 'demo-categorical-axis',
         keyForValues: 'category',
-        ticks: {
-          count: 5
-        },
         position: {
           type: CONSTANTS.AXIS.POSITIONS.bottom
         },

--- a/src/elements/GeoChart/GeoChart.13.3.scatter-plot-chart-quadrants.examples.md
+++ b/src/elements/GeoChart/GeoChart.13.3.scatter-plot-chart-quadrants.examples.md
@@ -11,19 +11,26 @@
         <geo-chart
           v-if="chartConfig && isGraphVisible"
           :config="chartConfig"
-          class2="u-geo-chart--hidden-axis"
         />
       </div>
       <geo-bordered-box
         v-if="isGraphVisible"
-        style="height: 100px"
+        style="height: fit-content"
       >
         <geo-bordered-box-header>
           Click on a dot to get info
         </geo-bordered-box-header>
-        <geo-list-item>
+        <div style="height: 100px">
           {{ popupText }}
-        </geo-list-item>
+        </div>
+        <geo-bordered-box-footer>
+          <geo-secondary-button
+            :disabled="!hasDotClicked"
+            @click="unclickDot"
+          >
+            Unclick dot
+          </geo-secondary-button>
+        </geo-bordered-box-footer>
       </geo-bordered-box>
     </div>
     <geo-primary-button @click="randomizeData()">
@@ -190,6 +197,12 @@ export default {
         this.hasDotClicked = true
         this.popupText = `x=${d.x} y=${d.y}`
       }
+    },
+
+    unclickDot () {
+      const dot = document.querySelector('.is-clicked')
+      const clickEvent = new MouseEvent('click')
+      dot.dispatchEvent(clickEvent)
     }
   }
 }

--- a/src/elements/GeoChart/GeoChartAxis/GeoChartAxis.d.ts
+++ b/src/elements/GeoChart/GeoChartAxis/GeoChartAxis.d.ts
@@ -68,6 +68,7 @@ declare namespace GeoChart {
     cssClasses?: (originalClasses: string[]) => string[]
     ticks: {
       count?: number
+      forceTickCount?: boolean
       cssClasses?: (originalClasses: string[], value: Domain, index: number) => string[]
       format?: (d: object, i: number) => {
         text: string

--- a/src/elements/GeoChart/GeoChartAxis/GeoChartAxis.js
+++ b/src/elements/GeoChart/GeoChartAxis/GeoChartAxis.js
@@ -415,9 +415,10 @@ export function createCustomizedTickArray (firstOfDomain, lastOfDomain, tickCoun
   const domainRange = Math.abs(firstOfDomain - lastOfDomain)
   const ticksStep = domainRange / (tickCount - 1)
   const tickToDisplay = _.map(_.times(tickCount), (id) => {
-    return firstOfDomain < lastOfDomain
+    return _.round(firstOfDomain < lastOfDomain
       ? firstOfDomain + (ticksStep * id)
       : firstOfDomain - (ticksStep * id)
+    , 3)
   })
   return tickToDisplay
 }

--- a/src/elements/GeoChart/GeoChartAxis/GeoChartAxis.js
+++ b/src/elements/GeoChart/GeoChartAxis/GeoChartAxis.js
@@ -188,10 +188,10 @@ export function getAxis (singleAxisOptions) {
   const isTickCountForced = _.isFinite(tickCount)
 
   if (isTickCountForced) {
-    if (!isForcedCustomizedTick) {
+    if (!isForcedCustomizedTick || tickCount === 1) {
       d3Axis.ticks(tickCount)
     } else {
-      const axisDomain = singleAxisOptions.scale.axisScale.domain()
+      const axisDomain = scale.domain()
       const tickToDisplay = createCustomizedTickArray(_.first(axisDomain), _.last(axisDomain), tickCount)
       d3Axis.tickValues(tickToDisplay)
     }
@@ -411,13 +411,12 @@ function positionLabel (label, singleAxisOptions, globalAxesConfig) {
   }
 }
 
-function createCustomizedTickArray (firstOfDomain, lastOfDomain, tickCount) {
-  const tickToDisplay = new Array(tickCount)
+export function createCustomizedTickArray (firstOfDomain, lastOfDomain, tickCount) {
   const domainRange = Math.abs(firstOfDomain - lastOfDomain)
   const ticksStep = domainRange / (tickCount - 1)
-  _.times(tickToDisplay.length, (id) => {
-    tickToDisplay[id] = firstOfDomain < lastOfDomain
-      ? firstOfDomain + ticksStep * id
+  const tickToDisplay = _.map(_.times(tickCount), (id) => {
+    return firstOfDomain < lastOfDomain
+      ? firstOfDomain + (ticksStep * id)
       : firstOfDomain - (ticksStep * id)
   })
   return tickToDisplay

--- a/src/elements/GeoChart/GeoChartAxis/GeoChartAxis.js
+++ b/src/elements/GeoChart/GeoChartAxis/GeoChartAxis.js
@@ -184,9 +184,17 @@ export function getAxis (singleAxisOptions) {
   const d3Axis = getD3Axis()
 
   const tickCount = _.get(singleAxisOptions, 'ticks.count')
+  const isForcedCustomizedTick = _.get(singleAxisOptions, 'ticks.forceTickCount')
   const isTickCountForced = _.isFinite(tickCount)
+
   if (isTickCountForced) {
-    d3Axis.ticks(tickCount)
+    if (!isForcedCustomizedTick) {
+      d3Axis.ticks(tickCount)
+    } else {
+      const axisDomain = singleAxisOptions.scale.axisScale.domain()
+      const tickToDisplay = createCustomizedTickArray(_.first(axisDomain), _.last(axisDomain), tickCount)
+      d3Axis.tickValues(tickToDisplay)
+    }
   }
 
   const tickFormat = _.get(singleAxisOptions, 'ticks.format')
@@ -401,4 +409,16 @@ function positionLabel (label, singleAxisOptions, globalAxesConfig) {
       console.error(`Unknown position ${axisType}`)
       break
   }
+}
+
+function createCustomizedTickArray (firstOfDomain, lastOfDomain, tickCount) {
+  const tickToDisplay = new Array(tickCount)
+  const domainRange = Math.abs(firstOfDomain - lastOfDomain)
+  const ticksStep = domainRange / (tickCount - 1)
+  _.times(tickToDisplay.length, (id) => {
+    tickToDisplay[id] = firstOfDomain < lastOfDomain
+      ? firstOfDomain + ticksStep * id
+      : firstOfDomain - (ticksStep * id)
+  })
+  return tickToDisplay
 }

--- a/src/elements/GeoChart/GeoChartConfigs/GeoChartConfig.js
+++ b/src/elements/GeoChart/GeoChartConfigs/GeoChartConfig.js
@@ -232,10 +232,7 @@ export const axisConfigJsonSchema = {
           minimum: 0
         },
         forceTickCount: {
-          type: 'boolean',
-          default: function () {
-            return false
-          }
+          type: 'boolean'
         },
         // Function taking as first parameter an array of CSS classes that would
         // be set by default. Should return the array of CSS classes to be

--- a/src/elements/GeoChart/GeoChartConfigs/GeoChartConfig.js
+++ b/src/elements/GeoChart/GeoChartConfigs/GeoChartConfig.js
@@ -231,6 +231,12 @@ export const axisConfigJsonSchema = {
           type: ['integer', 'null'],
           minimum: 0
         },
+        forceTickCount: {
+          type: 'boolean',
+          default: function () {
+            return false
+          }
+        },
         // Function taking as first parameter an array of CSS classes that would
         // be set by default. Should return the array of CSS classes to be
         // finally set. Some additional CSS classes required by D3 might be added

--- a/src/elements/GeoChart/GeoChartQuadrant/GeoChartQuadrant.js
+++ b/src/elements/GeoChart/GeoChartQuadrant/GeoChartQuadrant.js
@@ -326,19 +326,19 @@ function renderQuadrantLabels (group, d3TipInstance, singleQuadrantOptions, allQ
     switch (d.id) {
       case QUADRANT_LABEL.topLeft:
         translation.x = axesMargin.left
-        translation.y = axesMargin.bottom - (DEFAULT_LINE_HEIGHT / 2)
+        translation.y = axesMargin.top - (DEFAULT_LINE_HEIGHT / 2)
         break
       case QUADRANT_LABEL.topRight:
-        translation.x = axesSize.width - textWidth
-        translation.y = axesMargin.bottom - (DEFAULT_LINE_HEIGHT / 2)
+        translation.x = axesSize.width - axesMargin.right - textWidth
+        translation.y = axesMargin.top - (DEFAULT_LINE_HEIGHT / 2)
         break
       case QUADRANT_LABEL.bottomLeft:
         translation.x = axesMargin.left
-        translation.y = axesSize.height - DEFAULT_LINE_HEIGHT
+        translation.y = axesSize.height - axesMargin.bottom + DEFAULT_LINE_HEIGHT
         break
       case QUADRANT_LABEL.bottomRight:
-        translation.x = axesSize.width - textWidth
-        translation.y = axesSize.height - DEFAULT_LINE_HEIGHT
+        translation.x = axesSize.width - axesMargin.right - textWidth
+        translation.y = axesSize.height - axesMargin.bottom + DEFAULT_LINE_HEIGHT
         break
     }
     return `translate(${translation.x}, ${translation.y})`

--- a/src/elements/GeoChart/GeoChartScatterPlot/GeoChartScatterPlot.js
+++ b/src/elements/GeoChart/GeoChartScatterPlot/GeoChartScatterPlot.js
@@ -267,6 +267,7 @@ function renderSingleGroup (group, d3TipInstance, singleGroupOptions, globalOpti
       .style('stroke', '#9B9B9B')
       .style('stroke-width', '8')
       .style('stroke-opacity', '0.4')
+      .classed('is-clicked', true)
   }
 
   function unclickedStyle (element, d) {
@@ -277,5 +278,6 @@ function renderSingleGroup (group, d3TipInstance, singleGroupOptions, globalOpti
       .style('stroke', 'white')
       .style('stroke-width', '2')
       .style('stroke-opacity', '1')
+      .classed('is-clicked', false)
   }
 }

--- a/src/styles/elements/GeoChart/_geo-chart.scss
+++ b/src/styles/elements/GeoChart/_geo-chart.scss
@@ -1,6 +1,4 @@
 
-$DEFAULT_LINE_HEIGHT: 12px;
-
 .geo-chart {
   &, svg {
     height: 100%;
@@ -40,25 +38,6 @@ $DEFAULT_LINE_HEIGHT: 12px;
 
 .geo-chart-quadrant-line {
   color: $color-blue;
-}
-
-.geo-chart-axis--with-quadrant {
-  .domain,
-  line {
-    display: none;
-  }
-  &.geo-chart-axis--left text {
-    transform: translate(-$DEFAULT_LINE_HEIGHT, 0)
-  }
-  &.geo-chart-axis--top text {
-    transform: translate(0, -$DEFAULT_LINE_HEIGHT)
-  }
-  &.geo-chart-axis--bottom text {
-    transform: translate(0, $DEFAULT_LINE_HEIGHT)
-  }
-  &.geo-chart-axis--right text {
-    transform: translate($DEFAULT_LINE_HEIGHT, 0)
-  }
 }
 
 .geo-chart-tooltip {

--- a/test/unit/specs/elements/GeoChart/GeoChartAxis.spec.js
+++ b/test/unit/specs/elements/GeoChart/GeoChartAxis.spec.js
@@ -369,6 +369,59 @@ describe('GeoChartAxis', function () {
         expect(wrapper.find('.geo-chart-axis-label--left').exists()).toBe(true)
         expect(wrapper.find('.geo-chart-axis-label--left').text()).toBe('Test label')
       })
+
+      it('Should render correct number of ticks when forced', function () {
+        const tickCount = 5
+        const startDomain = 100
+        const endDomain = 0
+
+        const axisWithoutForcedTicks = _.merge({}, linearAxisConfig, {
+          ticks: {
+            count: tickCount
+          },
+          scale: {
+            domain: {
+              start: startDomain,
+              end: endDomain
+            }
+          },
+          position: { type: GeoChart.constants.AXIS.POSITIONS.left }
+        })
+
+        const axisWithForcedTicks = _.merge({}, axisWithoutForcedTicks)
+        axisWithForcedTicks.ticks.forceTickCount = true
+
+        const wrapper = mount(GeoChart, {
+          propsData: {
+            config: {
+              axisGroups: [axisWithoutForcedTicks]
+            }
+          }
+        })
+
+        const wrapper2 = mount(GeoChart, {
+          propsData: {
+            config: {
+              axisGroups: [axisWithForcedTicks]
+            }
+          }
+        })
+
+        flushD3Transitions()
+
+        expect(wrapper.find('.geo-chart').exists()).toBe(true)
+        expect(wrapper.find('.geo-chart-axis').exists()).toBe(true)
+        expect(wrapper.find('.geo-chart-axis .tick').exists()).toBe(true)
+        expect(wrapper.findAll('.geo-chart-axis .tick')).toHaveLength(tickCount + 1)
+
+        expect(wrapper2.find('.geo-chart').exists()).toBe(true)
+        expect(wrapper2.find('.geo-chart-axis').exists()).toBe(true)
+        expect(wrapper2.find('.geo-chart-axis .tick').exists()).toBe(true)
+        expect(wrapper2.findAll('.geo-chart-axis .tick')).toHaveLength(tickCount)
+
+        const ticksArray = [100, 75, 50, 25, 0]
+        expect(GeoChartAxis.createCustomizedTickArray(startDomain, endDomain, tickCount)).toMatchObject(ticksArray)
+      })
     })
 
     describe('Simply-positioned axes', function () {

--- a/test/unit/specs/elements/GeoChart/GeoChartAxis.spec.js
+++ b/test/unit/specs/elements/GeoChart/GeoChartAxis.spec.js
@@ -121,6 +121,33 @@ describe('GeoChartAxis', function () {
     })
   })
 
+  describe('#createCustomizedTickArray', function () {
+    it('With start domain bigger then end domain', function () {
+      const ticksArray = [100, 75, 50, 25, 0]
+      expect(GeoChartAxis.createCustomizedTickArray(100, 0, 5)).toMatchObject(ticksArray)
+    })
+    it('With negative domain', function () {
+      const ticksArray = [-20, -15, -10]
+      expect(GeoChartAxis.createCustomizedTickArray(-20, -10, 3)).toMatchObject(ticksArray)
+    })
+    it('With negative domain and start bigger then end', function () {
+      const ticksArray = [-100, -150, -200]
+      expect(GeoChartAxis.createCustomizedTickArray(-100, -200, 3)).toMatchObject(ticksArray)
+    })
+    it('With null domain', function () {
+      const ticksArray = [0, 0, 0]
+      expect(GeoChartAxis.createCustomizedTickArray(0, 0, 3)).toMatchObject(ticksArray)
+    })
+    it('With small domain', function () {
+      const ticksArray = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+      expect(GeoChartAxis.createCustomizedTickArray(0, 1, 11)).toMatchObject(ticksArray)
+    })
+    it('With no ticks', function () {
+      const ticksArray = []
+      expect(GeoChartAxis.createCustomizedTickArray(100, 200, 0)).toMatchObject(ticksArray)
+    })
+  })
+
   describe('#render', function () {
     const tickCount = 5
     const linearAxisConfig = {
@@ -368,59 +395,6 @@ describe('GeoChartAxis', function () {
         expect(wrapper.find('.geo-chart-axis-label').exists()).toBe(true)
         expect(wrapper.find('.geo-chart-axis-label--left').exists()).toBe(true)
         expect(wrapper.find('.geo-chart-axis-label--left').text()).toBe('Test label')
-      })
-
-      it('Should render correct number of ticks when forced', function () {
-        const tickCount = 5
-        const startDomain = 100
-        const endDomain = 0
-
-        const axisWithoutForcedTicks = _.merge({}, linearAxisConfig, {
-          ticks: {
-            count: tickCount
-          },
-          scale: {
-            domain: {
-              start: startDomain,
-              end: endDomain
-            }
-          },
-          position: { type: GeoChart.constants.AXIS.POSITIONS.left }
-        })
-
-        const axisWithForcedTicks = _.merge({}, axisWithoutForcedTicks)
-        axisWithForcedTicks.ticks.forceTickCount = true
-
-        const wrapper = mount(GeoChart, {
-          propsData: {
-            config: {
-              axisGroups: [axisWithoutForcedTicks]
-            }
-          }
-        })
-
-        const wrapper2 = mount(GeoChart, {
-          propsData: {
-            config: {
-              axisGroups: [axisWithForcedTicks]
-            }
-          }
-        })
-
-        flushD3Transitions()
-
-        expect(wrapper.find('.geo-chart').exists()).toBe(true)
-        expect(wrapper.find('.geo-chart-axis').exists()).toBe(true)
-        expect(wrapper.find('.geo-chart-axis .tick').exists()).toBe(true)
-        expect(wrapper.findAll('.geo-chart-axis .tick')).toHaveLength(tickCount + 1)
-
-        expect(wrapper2.find('.geo-chart').exists()).toBe(true)
-        expect(wrapper2.find('.geo-chart-axis').exists()).toBe(true)
-        expect(wrapper2.find('.geo-chart-axis .tick').exists()).toBe(true)
-        expect(wrapper2.findAll('.geo-chart-axis .tick')).toHaveLength(tickCount)
-
-        const ticksArray = [100, 75, 50, 25, 0]
-        expect(GeoChartAxis.createCustomizedTickArray(startDomain, endDomain, tickCount)).toMatchObject(ticksArray)
       })
     })
 


### PR DESCRIPTION
- use class `geo-chart-axis--with-quadrant` only in demo (and not always) to be able to customize it in the app
- fix label position for `GeoChartQuadrant`
- add class to handle clicking on a scatter plot dot from an external component
- add property to force `ticks` number in axis (in the previous way, d3 rounded the number of ticks to a multiple of 2, 5, or 10 when creating ticks and so didn't accept all values)