### PR TITLE
add animationDuration prop to geoScatterPlot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 29.5.4
+
+New:
+
+- `animationsDuration` prop to have a specific animation time for `GeoScatterPlot`
+
 ## 29.5.3
 
 Fix:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "29.5.3",
+  "version": "29.5.4-beta.0",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "29.5.4-beta.0",
+  "version": "29.5.4",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/src/elements/GeoChart/GeoChart.13.4.scatter-plot-not-interactive.examples.md
+++ b/src/elements/GeoChart/GeoChart.13.4.scatter-plot-not-interactive.examples.md
@@ -87,7 +87,7 @@ export default {
             bottom: 30,
             left: 50
           },
-          animationsDurationInMilliseconds: 0
+          animationsDurationInMilliseconds: 800
         },
         axisGroups: [
           this.linearAxisConfig,
@@ -103,7 +103,8 @@ export default {
             getFillColor: this.getFillColor,
             getOpacity: this.getOpacity,
             onDotClick: this.onDotClick,
-            blockMouseEvents: true
+            blockMouseEvents: true,
+            animationsDuration: 0
           }
         ]
       }
@@ -124,6 +125,11 @@ export default {
 
     toggleGraph () {
       this.isGraphVisible = !this.isGraphVisible
+      if (this.isGraphVisible) {
+        this.$nextTick(function () {
+          this.manualClick()
+        })
+      }
     },
 
     getOpacity (d, i) {

--- a/src/elements/GeoChart/GeoChartConfigs/GeoChartConfig.js
+++ b/src/elements/GeoChart/GeoChartConfigs/GeoChartConfig.js
@@ -814,6 +814,9 @@ export const scatterPlotConfigSchema = {
     blockMouseEvents: {
       type: 'boolean'
     },
+    animationsDuration: {
+      type: 'number'
+    },
     mainDimension: {
       type: 'string',
       enum: _.values(dimensionUtils.DIMENSIONS_2D)

--- a/src/elements/GeoChart/GeoChartConfigs/GeoChartConfigAdapter.scatterPlot.mixin.js
+++ b/src/elements/GeoChart/GeoChartConfigs/GeoChartConfigAdapter.scatterPlot.mixin.js
@@ -45,6 +45,7 @@ export default {
           getOpacity: singleScatterPlotGroupConfig.getOpacity,
           onDotClick: singleScatterPlotGroupConfig.onDotClick,
           blockMouseEvents: singleScatterPlotGroupConfig.blockMouseEvents,
+          animationsDuration: singleScatterPlotGroupConfig.animationsDuration,
           tooltip: tooltipConfig,
           cssClasses: singleScatterPlotGroupConfig.cssClasses,
           groupKey: singleScatterPlotGroupConfig.groupKey

--- a/src/elements/GeoChart/GeoChartScatterPlot/GeoChartScatterPlot.d.ts
+++ b/src/elements/GeoChart/GeoChartScatterPlot/GeoChartScatterPlot.d.ts
@@ -2,6 +2,7 @@ declare namespace GeoChart {
   interface ScatterPlotGroupConfig<HorizontalDomain, VerticalDomain> extends BidimensionalGroupConfig<HorizontalDomain, VerticalDomain> {
     data: [number, number][]
     blockMouseEvents?: boolean
+    animationsDuration?: number
     getRadius?: (item: object, index: number) => string | number | null | undefined
     getFillColor?: (item: object, index: number) => string | null | undefined
     getOpacity?: (item: object, index: number) => string | number | null | undefined

--- a/src/elements/GeoChart/GeoChartScatterPlot/GeoChartScatterPlot.js
+++ b/src/elements/GeoChart/GeoChartScatterPlot/GeoChartScatterPlot.js
@@ -126,6 +126,7 @@ export function render (d3Instance, d3TipInstance, options, globalOptions) {
 
 function renderSingleGroup (group, d3TipInstance, singleGroupOptions, globalOptions, d3Instance) {
   const singleDotBaseClass = 'geo-chart-scatter-plot__dot'
+  const animationsDuration = _.defaultTo(singleGroupOptions.animationsDuration, globalOptions.chart.animationsDurationInMilliseconds)
 
   _.each(singleGroupOptions.data, (dot, i) => {
     dot.index = i
@@ -157,10 +158,10 @@ function renderSingleGroup (group, d3TipInstance, singleGroupOptions, globalOpti
     .on('mouseout', handleMouseOut)
     .on('click', handleClick)
 
-  const allDotsAfterTransition = globalOptions.chart.animationsDurationInMilliseconds
+  const allDotsAfterTransition = animationsDuration
     ? allDots
       .transition()
-      .duration(globalOptions.chart.animationsDurationInMilliseconds)
+      .duration(animationsDuration)
     : allDots
 
   allDotsAfterTransition
@@ -176,7 +177,7 @@ function renderSingleGroup (group, d3TipInstance, singleGroupOptions, globalOpti
   dots
     .exit()
     .transition()
-    .duration(globalOptions.chart.animationsDurationInMilliseconds)
+    .duration(animationsDuration)
     .attr('r', 0)
     .style('opacity', 0)
     .remove()


### PR DESCRIPTION
In the app for SA2.0, we need the animation for the dots to be independent from the axis, guidelines and quadrant ones (because we don't want any animation on update for the scatterPlot dots)