### PR TITLE
Add support for max selected items in geo-tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 35.2.0
+Changed:
+- `GeoTree`: Add support for max. number of items checked using the prop `max-checked-items`
+- `GeoTreeItem`: Add support for disabling item input and for hiding folder input using the following props: `is-item-select-disabled` and `is-folder-select-hidden`
 ## 35.1.0
 Changed:
 - `GeoTree` and `GeoTreeItem`: In the `check-folder` event, we are now including the subcategories.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "35.1.0",
+  "version": "35.2.0-beta.4",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "35.2.0-beta.5",
+  "version": "35.2.0",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "35.2.0-beta.4",
+  "version": "35.2.0-beta.5",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/src/elements/GeoTree/GeoTree.examples.md
+++ b/src/elements/GeoTree/GeoTree.examples.md
@@ -801,3 +801,133 @@ export default {
 }
 </script>
 ```
+
+### With max number of items checked
+
+```vue live
+<template>
+    <geo-tree
+        key-for-id="id"
+        key-for-subcategory="subcategories"
+        key-for-label="label"
+        :categories="categories"
+        :checked-items="checkedCategories"
+        :max-checked-items="4"
+        @check-item="handleCheckItem"
+    ></geo-tree>  
+</template>
+  
+<script>  
+export default {
+  name: 'GeoTreeDemo',
+  data () {
+    return {
+      checkedCategories: {
+        pineapple: true
+      },
+      categories: 
+        [  
+            {  
+                id: 'fruits',  
+                label: 'Fruits',  
+                subcategories: [  
+                    {  
+                        id: 'tropical-fruits',  
+                        label: 'Tropical fruits',  
+                        subcategories: [  
+                            { id: 'pineapple', label: 'Pineapple' },  
+                            { id: 'banana', label: 'Banana' },  
+                            { id: 'coconut',label: 'Coconut'},  
+                            { id: 'avocado', label: 'Avocado' }  
+                        ]  
+                    },  
+                    {  
+                        id: 'citrus-fruits',  
+                        label: 'Citrus fruits',  
+                        subcategories: [  
+                            { id: 'orange', label: 'Orange' },  
+                            { id: 'lime', label: 'Lime'},  
+                            { id: 'grapefruit', label: 'GrapeFruit' },  
+                            { id: 'mandarin',label: 'Mandarin'},  
+                            { id: 'pomelo', label: 'Pomelo' }  
+                        ]  
+                    },
+                    {  
+                        id: 'invented-fruits',  
+                        label: 'Invented fruits',  
+                        subcategories: [
+                          {
+                            id: 'not-oranges',
+                            label: 'Not oranges',
+                            subcategories: []
+                          }
+                        ]  
+                    },
+                    {  
+                        id: 'epic-fruits',  
+                        label: 'Epic fruits',  
+                        subcategories: [
+                          {
+                            id: 'legendary-fruits',
+                            label: 'Legendary fruits',
+                            subcategories: []
+                          },
+                          {
+                            id: 'awesome-fruits',
+                            label: 'Awesome fruits',
+                            subcategories: [
+                              { id: 'sweet-melon', label: 'Sweet melon' }
+                            ]
+                          }
+                        ]  
+                    }, 
+                    {  
+                        id: 'sweet-fruits',  
+                        label: 'Sweet',  
+                        subcategories: [  
+                            {id: 'pear',label: 'Pear'},  
+                            {id: 'apple',label: 'Apple'},  
+                            {id: 'redGrapes',label: 'Red Grapes'}  
+                        ]  
+                    } 
+                ]  
+            },  
+            {  
+                id: 'vegetables',  
+                label: 'Vegetables',  
+                subcategories: [  
+                    {  
+                        id: 'vegetables-fruits',  
+                        label: 'Fruits',  
+                        subcategories: [  
+                            { id: 'eggplant',  label: 'Eggplant' },  
+                            { id: 'pepper',  label: 'Pepper' }  
+                        ]  
+                    },  
+                    {  
+                        id: 'bulbs',  
+                        label: 'Bulbs',  
+                        subcategories: [  
+                            { id: 'onion',  label: 'Onion' },  
+                            { id: 'leek', label: 'Leek' },  
+                            { 
+                                id: 'garlic', label: 'Garlic',
+                            }  
+                        ]  
+                    },
+                ]  
+            }  
+        ]
+    }
+  },
+  methods: {
+    handleCheckItem (categoryId, isChecked, isDelegated) {
+      this.$set(this.checkedCategories, categoryId, isChecked)
+    },
+    handleCheckFolder (categoryId, isChecked, isDelegated) {
+      // Use this event if you want to manually handle folders
+    }
+  }
+}
+</script>
+```

--- a/src/elements/GeoTree/GeoTree.vue
+++ b/src/elements/GeoTree/GeoTree.vue
@@ -48,7 +48,7 @@
             :draggable-group="draggableGroup"
             :is-single-select-mode="isSingleSelectMode"
             :is-folder-select-hidden="!!maxCheckedItems"
-            :is-item-select-disabled="hasMaxCategoriesSelected"
+            :is-item-select-disabled="hasMaxItemsSelected"
             @check-item="handleCheckItem"
             @check-folder="handleCheckFolder"
             @toggleExpand="handleToggleExpand"
@@ -259,7 +259,7 @@ export default {
         ? this.filterCategories(this.sortedCategories, this.searchQuery)
         : this.sortedCategories
     },
-    hasMaxCategoriesSelected () {
+    hasMaxItemsSelected () {
       if (!this.maxCheckedItems) return false
 
       return this.nSelectedItems >= this.maxCheckedItems

--- a/src/elements/GeoTree/GeoTree.vue
+++ b/src/elements/GeoTree/GeoTree.vue
@@ -244,8 +244,7 @@ export default {
   data () {
     return {
       searchQuery: '',
-      expandedCategories: {},
-      nSelectedCategories: 0
+      expandedCategories: {}
     }
   },
   computed: {
@@ -264,27 +263,23 @@ export default {
       if (!this.maxCheckedItems) return false
 
       return this.nSelectedCategories >= this.maxCheckedItems
+    },
+    nSelectedCategories () {
+      return _.size(_.filter(this.checkedItems))
     }
   },
   watch: {
     dynamicExpandedCategories (newExpandedCategories) {
       this.expandedCategories = newExpandedCategories || {}
-    },
-    checkedItems (newCheckedItems) {
-      this.nSelectedCategories = _.size(_.filter(newCheckedItems))
     }
   },
   mounted () {
     if (this.dynamicExpandedCategories) {
       this.expandedCategories = _.assign({}, this.expandedCategories, this.dynamicExpandedCategories)
     }
-    if (_.size(this.checkedItems)) {
-      this.nSelectedCategories = _.size(_.filter(this.checkedItems))
-    }
   },
   methods: {
     handleCheckItem (category, isChecked, isDelegated) {
-      isChecked ? this.nSelectedCategories++ : this.nSelectedCategories--
       this.$emit('check-item', category[this.keyForId], isChecked, category, isDelegated)
     },
     handleCheckFolder (category, isChecked, isDelegated) {

--- a/src/elements/GeoTree/GeoTree.vue
+++ b/src/elements/GeoTree/GeoTree.vue
@@ -262,9 +262,9 @@ export default {
     hasMaxCategoriesSelected () {
       if (!this.maxCheckedItems) return false
 
-      return this.nSelectedCategories >= this.maxCheckedItems
+      return this.nSelectedItems >= this.maxCheckedItems
     },
-    nSelectedCategories () {
+    nSelectedItems () {
       return _.size(_.filter(this.checkedItems))
     }
   },

--- a/src/elements/GeoTree/GeoTree.vue
+++ b/src/elements/GeoTree/GeoTree.vue
@@ -47,6 +47,8 @@
             :expanded-icon="expandedIcon"
             :draggable-group="draggableGroup"
             :is-single-select-mode="isSingleSelectMode"
+            :is-folder-select-hidden="!!maxCheckedItems"
+            :is-item-select-disabled="hasMaxCategoriesSelected"
             @check-item="handleCheckItem"
             @check-folder="handleCheckFolder"
             @toggleExpand="handleToggleExpand"
@@ -180,6 +182,13 @@ export default {
       default: () => ({})
     },
     /**
+    * Max number of checked items
+    */
+    maxCheckedItems: {
+      type: Number,
+      required: false
+    },
+    /**
      * Initial categories to be expanded, with truthy/falsy category ids, it's being watched to react to outside changes
      */
     dynamicExpandedCategories: {
@@ -235,7 +244,8 @@ export default {
   data () {
     return {
       searchQuery: '',
-      expandedCategories: {}
+      expandedCategories: {},
+      nSelectedCategories: 0
     }
   },
   computed: {
@@ -249,20 +259,32 @@ export default {
       return this.searchQuery
         ? this.filterCategories(this.sortedCategories, this.searchQuery)
         : this.sortedCategories
+    },
+    hasMaxCategoriesSelected () {
+      if (!this.maxCheckedItems) return false
+
+      return this.nSelectedCategories >= this.maxCheckedItems
     }
   },
   watch: {
     dynamicExpandedCategories (newExpandedCategories) {
       this.expandedCategories = newExpandedCategories || {}
+    },
+    checkedItems (newCheckedItems) {
+      this.nSelectedCategories = _.size(_.filter(newCheckedItems))
     }
   },
   mounted () {
     if (this.dynamicExpandedCategories) {
       this.expandedCategories = _.assign({}, this.expandedCategories, this.dynamicExpandedCategories)
     }
+    if (_.size(this.checkedItems)) {
+      this.nSelectedCategories = _.size(_.filter(this.checkedItems))
+    }
   },
   methods: {
     handleCheckItem (category, isChecked, isDelegated) {
+      isChecked ? this.nSelectedCategories++ : this.nSelectedCategories--
       this.$emit('check-item', category[this.keyForId], isChecked, category, isDelegated)
     },
     handleCheckFolder (category, isChecked, isDelegated) {

--- a/src/elements/GeoTree/GeoTreeItem.vue
+++ b/src/elements/GeoTree/GeoTreeItem.vue
@@ -42,7 +42,7 @@
           />
         </span>
         <input
-          v-if="!isSingleSelectMode || isSingleItem"
+          v-if="!isItemInputHidden"
           :id="category[keyForId]"
           :checked="isChecked"
           :indeterminate.prop="isIndeterminate"
@@ -85,6 +85,8 @@
           :description-icon="descriptionIcon"
           :draggable-group="draggableGroup"
           :is-single-select-mode="isSingleSelectMode"
+          :is-folder-select-hidden="isFolderSelectHidden"
+          :is-item-select-disabled="isItemSelectDisabled"
           @check-item="handleCheckChildItem"
           @check-folder="handleCheckChildFolder"
           @click="handleClick"
@@ -159,6 +161,20 @@ export default {
       required: true
     },
     /**
+     * Boolean indicating if select folders is hidden
+     */
+    isFolderSelectHidden: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * Boolean indicating if select items is disabled
+     */
+    isItemSelectDisabled: {
+      type: Boolean,
+      default: false
+    },
+    /**
      * Icon used to alert about some extra info displayed in a popover
      */
     descriptionIcon: {
@@ -228,8 +244,6 @@ export default {
       return !this.isChecked && isSomeChildSelected(this.category)
     },
     isChecked () {
-      if (this.isInputDisabled) return false
-
       const allAreChildrenSelected = category => {
         const selectableChildren = this.getSelectableChildrenForCategory(category)
         return _.every(selectableChildren, subCategory => {
@@ -265,10 +279,17 @@ export default {
       return this.isExpanded && !this.expandedIcon
     },
     isInputDisabled () {
-      return !this.isSingleItem && this.totalSelectableCategoryChildren === 0
+      return this.isSingleItem
+        ? this.isItemSelectDisabled && !this.isChecked
+        : this.totalSelectableCategoryChildren === 0
     },
     inputType () {
       return this.isSingleSelectMode ? 'radio' : 'checkbox'
+    },
+    isItemInputHidden () {
+      if (this.isSingleItem) return false
+
+      return this.isSingleSelectMode || this.isFolderSelectHidden
     }
   },
   methods: {
@@ -277,6 +298,7 @@ export default {
      */
     handleClick () {
       if (this.isSingleItem) {
+        if (this.isInputDisabled) return
         this.handleCheck(this.category, !this.isChecked)
       } else {
         this.toggleExpand(this.category)


### PR DESCRIPTION
With the current data structure we have, geo-tree does not have internal object to know which categories are checked, that's why i need to rely on the watcher and the event we send

Regarding tests, I added the bullet point to the current task we have to improve them