### PR TITLE
Fix geo-tree reactivity when using pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 37.1.2
+Fix:
+- `GeoTree`: Fix issues with reactivity when using pagination.
+
 ## 37.1.1
 Fix:
 - `GeoSelect`: Fix issues when filtering everything on geo select with groups when using `searchable` mode with pagination.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "37.1.1",
+  "version": "37.1.2-beta.0",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "37.1.2-beta.1",
+  "version": "37.1.2",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoblink/design-system",
-  "version": "37.1.2-beta.0",
+  "version": "37.1.2-beta.1",
   "description": "Geoblink Design System for Vue.js",
   "author": "Geoblink <contact@geoblink.com>",
   "main": "dist/system.js",

--- a/src/elements/GeoTree/GeoTree.vue
+++ b/src/elements/GeoTree/GeoTree.vue
@@ -37,7 +37,7 @@
         >
           <geo-tree-item
             v-for="category in visibleItems"
-            :key="category[keyForId]"
+            :key="`${category[keyForId]}-${searchQuery}`"
             :class="dragClassToIgnore"
             :category="category"
             :key-for-id="keyForId"
@@ -54,6 +54,7 @@
             :is-item-select-disabled="hasMaxItemsSelected"
             :has-load-more-button="hasLoadMoreButton"
             :page-size="pageSize"
+            :search-query="searchQuery"
             @check-item="handleCheckItem"
             @check-folder="handleCheckFolder"
             @toggleExpand="handleToggleExpand"

--- a/src/elements/GeoTree/GeoTree.vue
+++ b/src/elements/GeoTree/GeoTree.vue
@@ -37,7 +37,7 @@
         >
           <geo-tree-item
             v-for="category in visibleItems"
-            :key="`${category[keyForId]}-${nSelectedItems}`"
+            :key="category[keyForId]"
             :class="dragClassToIgnore"
             :category="category"
             :key-for-id="keyForId"

--- a/src/elements/GeoTree/GeoTreeItem.vue
+++ b/src/elements/GeoTree/GeoTreeItem.vue
@@ -84,7 +84,7 @@
       >
         <geo-tree-item
           v-for="subcategory in visibleItems"
-          :key="subcategory[keyForId]"
+          :key="`${subcategory[keyForId]}-${searchQuery}`"
           :class="dragClassToIgnore"
           :data-test="`subcategory-${subcategory[keyForId]}`"
           :category="subcategory"
@@ -102,6 +102,7 @@
           :is-item-select-disabled="isItemSelectDisabled"
           :has-load-more-button="hasLoadMoreButton"
           :page-size="pageSize"
+          :search-query="searchQuery"
           @check-item="handleCheckChildItem"
           @check-folder="handleCheckChildFolder"
           @click="handleClick"
@@ -297,6 +298,14 @@ export default {
       type: Number,
       required: false,
       default: 20
+    },
+    /**
+     * Current search query for filtering categories
+     */
+    searchQuery: {
+      type: String,
+      required: false,
+      default: ''
     }
   },
   data () {


### PR DESCRIPTION
I tried to spot why did we need it, tested in local and also in the app and I didn't spot any problem regarding this fix. Anyway, we should test in depth in QA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `GeoTree`/`GeoTreeItem` to key list items by `searchQuery` and propagate a new `searchQuery` prop to fix reactivity with pagination; bumps version to 37.1.2 and updates changelog.
> 
> - **GeoTree / GeoTreeItem**:
>   - Update `v-for` item `:key` to include ``${...}-${searchQuery}`` for both root and subcategory items.
>   - Add and propagate `searchQuery` prop in `GeoTreeItem`; pass it from `GeoTree`.
> - **Versioning / Docs**:
>   - Bump `package.json` version to `37.1.2`.
>   - Add changelog entry for the pagination reactivity fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13603bceeb314f16c9daadbba894278c792d055b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->